### PR TITLE
Add support for VS 2019

### DIFF
--- a/BrowseInRemoteGitRepo/source.extension.vsixmanifest
+++ b/BrowseInRemoteGitRepo/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
         <Tags>Git</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 15.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -21,7 +21,7 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.Net.Component.4.5.2.TargetingPack" Version="[14.0,16.0)" DisplayName=".NET Framework 4.5.2 targeting pack" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.Net.Component.4.5.2.TargetingPack" Version="[14.0,)" DisplayName=".NET Framework 4.5.2 targeting pack" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Hey Néstor!

As described here: https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/. Works like a charm.